### PR TITLE
Use term "sex" (scientific) instead of gender.

### DIFF
--- a/deck.json
+++ b/deck.json
@@ -1090,7 +1090,7 @@
             "__type__": "Note",
             "data": "",
             "fields": [
-                "Which has a higher mortality rate: male or female? ",
+                "Between males and females, who has a higher mortality rate due to COVID-19? ",
                 "Male",
                 "<a href=\"https://www.who.int/docs/default-source/coronaviruse/who-china-joint-mission-on-covid-19-final-report.pdf\">Report of the WHO-China Joint Mission on Coronavirus Disease 2019 (COVID-19)</a>&nbsp;- World Health Organization, Feb. 28, 2020",
                 "",

--- a/deck.json
+++ b/deck.json
@@ -1090,7 +1090,7 @@
             "__type__": "Note",
             "data": "",
             "fields": [
-                "Which sex seems to have a higher mortality rate?",
+                "Which has a higher mortality rate: male or female? ",
                 "Male",
                 "<a href=\"https://www.who.int/docs/default-source/coronaviruse/who-china-joint-mission-on-covid-19-final-report.pdf\">Report of the WHO-China Joint Mission on Coronavirus Disease 2019 (COVID-19)</a>&nbsp;- World Health Organization, Feb. 28, 2020",
                 "",

--- a/deck.json
+++ b/deck.json
@@ -1090,8 +1090,8 @@
             "__type__": "Note",
             "data": "",
             "fields": [
-                "Which sex seems to have a higher mortality rate",
-                "Men",
+                "Which sex seems to have a higher mortality rate?",
+                "Male",
                 "<a href=\"https://www.who.int/docs/default-source/coronaviruse/who-china-joint-mission-on-covid-19-final-report.pdf\">Report of the WHO-China Joint Mission on Coronavirus Disease 2019 (COVID-19)</a>&nbsp;- World Health Organization, Feb. 28, 2020",
                 "",
                 ""

--- a/deck.json
+++ b/deck.json
@@ -1091,7 +1091,7 @@
             "data": "",
             "fields": [
                 "Between males and females, who has a higher mortality rate due to COVID-19? ",
-                "Male",
+                "Males",
                 "<a href=\"https://www.who.int/docs/default-source/coronaviruse/who-china-joint-mission-on-covid-19-final-report.pdf\">Report of the WHO-China Joint Mission on Coronavirus Disease 2019 (COVID-19)</a>&nbsp;- World Health Organization, Feb. 28, 2020",
                 "",
                 ""

--- a/deck.json
+++ b/deck.json
@@ -1090,7 +1090,7 @@
             "__type__": "Note",
             "data": "",
             "fields": [
-                "Which gender (of the two \"main\" ones) seems to have a higher mortality rate",
+                "Which sex seems to have a higher mortality rate",
                 "Men",
                 "<a href=\"https://www.who.int/docs/default-source/coronaviruse/who-china-joint-mission-on-covid-19-final-report.pdf\">Report of the WHO-China Joint Mission on Coronavirus Disease 2019 (COVID-19)</a>&nbsp;- World Health Organization, Feb. 28, 2020",
                 "",


### PR DESCRIPTION
Gender is obviously contraversial, and there are many disagreements with it.
Sex is a scientific term (so it is what should be used for epidemiology) and most people agree there are two main sexes.